### PR TITLE
Custom grids

### DIFF
--- a/doc/tilematrix.md
+++ b/doc/tilematrix.md
@@ -1,25 +1,119 @@
-# The tilematrix objects
+# tilematrix
+
+The two base classes are ``TilePyramid`` which defines tile matrices in various zoom levels and its members, the``Tile`` objects. ``TilePyramid``
+
+## TilePyramid
+
+```python
+TilePyramid(grid_definition, tile_size=256)
+```
+* ``grid_definition``: Either one of the predefined grids (``geodetic`` or
+    ``mercator``) or a custom grid definition in form of a dictionary. For example:
+    ```python
+    {
+        "shape": (1, 1),
+        "bounds": (2426378.0132, 1528101.2618, 6293974.6215, 5395697.8701),
+        "is_global": False,
+        "epsg": 3035
+    }
+    ```
+    * ``shape`` (width, height): Indicates the number of tiles per column and row at **zoom level 0**.
+    * ``bounds`` (left, bottom, right, top): Units are CRS units.
+
+    Please note that the aspect ratios of ``shape`` and ``bounds`` have to be the same.
+    * Alternatively to ``epsg``, a custom ``proj`` string can be used:
+    ```python
+    "proj": """
+        +proj=ortho
+        +lat_0=-90
+        +lon_0=0
+        +x_0=0
+        +y_0=0
+        +ellps=WGS84
+        +units=m +no_defs
+    """
+    ```
+    * ``is_global``: Indicates whether the grid covers the whole globe or just a region.
+
+* ``tile_size``: Optional, specifies the target resolution of each tile (i.e. each tile will have 256x256 px). Default is ``256``.
+
+### Variables
+* ``type``: The projection it was initialized with (``geodetic``, ``mercator`` or ``custom``).
+* ``tile_size``: The pixelsize per tile it was initialized with (default ``256``).
+* ``left``: Left boundary of tile matrix.
+* ``top``: Top boundary of tile matrix.
+* ``right ``: Right boundary of tile matrix.
+* ``bottom ``: Bottom boundary of tile matrix.
+* ``x_size``: Horizontal size of tile matrix in map coordinates.
+* ``y_size``: Vertical size of tile matrix in map coordinates.
+* ``crs``: ``rasterio.crs.CRS()`` object.
+* ``srid``: Spatial reference ID (EPSG code) if available, else ``None``.
+
+### Methods
+
+#### Matrix properties
+* ``matrix_width(zoom)``: Returns the number of columns in the current tile matrix.
+    * ``zoom``: Zoom level.
+* ``matrix_height(zoom)``: Returns the number of rows in the current tile matrix.
+    * ``zoom``: Zoom level.
+
+#### Geometry
+* ``tile_x_size(zoom)``: Returns a float, indicating the width of each tile at this zoom level in ``TilePyramid`` CRS units.
+    * ``zoom``: Zoom level.
+* ``tile_y_size(zoom)``: Returns a floats, indicating the height of each tile at this zoom level in ``TilePyramid`` CRS units.
+    * ``zoom``: Zoom level.
+* ``pixel_x_size(zoom)``: Returns a float, indicating the vertical pixel size in ``TilePyramid`` CRS units.
+    * ``zoom``: Zoom level.
+* ``pixel_y_size(zoom)``: Returns a float, indicating the horizontal pixel size in ``TilePyramid`` CRS units.
+    * ``zoom``: Zoom level.
+* ``top_left_tile_coords(zoom, row, col)``: Returns a tuple of two floats, indicating the top left coordinates of the given tile.
+    * ``zoom``: Zoom level.
+    * ``row``: Row in ``TilePyramid``.
+    * ``col``: Column in ``TilePyramid``.
+* ``tile_bounds(zoom, row, col, pixelbuffer=None)``: Returns ``left``, ``bottom``, ``right``, ``top`` coordinates of given tile.
+    * ``zoom``: Zoom level.
+    * ``row``: Row in ``TilePyramid``.
+    * ``col``: Column in ``TilePyramid``.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+* ``tile_bbox(zoom, row, col, pixelbuffer=None)``: Returns the bounding box for given tile as a ``Polygon``.
+    * ``zoom``: Zoom level.
+    * ``row``: Row in ``TilePyramid``.
+    * ``col``: Column in ``TilePyramid``.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+
+
+#### Tiles
+* ``intersecting(tile)``: Return all tiles intersecting with tile. This helps translating between TilePyramids with different metatiling settings.
+    * ``tile``: ``Tile`` object.
+* ``tiles_from_bbox(geometry, zoom)``: Returns tiles intersecting with the given bounding box at given zoom level.
+    * ``geometry``: Must be a ``Polygon`` object.
+    * ``zoom``: Zoom level.
+* ``tiles_from_geom(geometry, zoom)``: Returns tiles intersecting with the given geometry at given zoom level.
+    * ``geometry``: Must be one out of ``Polygon``, ``MultiPolygon``, ``LineString``, ``MultiLineString``, ``Point``, ``MultiPoint``.
+    * ``zoom``: Zoom level.
+
 
 ## Tile
 
 ```python
 Tile(tile_pyramid, zoom, row, col)
 ```
-* ``tile_pyramid``: A ``TilePyramid`` or ``MetaTilePyramid`` this Tile belongs to.
+* ``tile_pyramid``: A ``TilePyramid`` this Tile belongs to.
 * ``zoom``: Tile zoom level.
 * ``row``: Tile row.
 * ``col``: Tile column.
 
 ### Variables
 After initializing, the object has the following properties:
-* ``tile_pyramid``: ``TilePyramid`` or ``MetaTilePyramid`` it was initialized with.
-* ``crs``: Coordinate reference system.
+* ``tile_pyramid`` or ``tp``: ``TilePyramid`` this Tile belongs to.
+* ``crs``: ``rasterio.crs.CRS()`` object.
+* ``srid``: Spatial reference ID (EPSG code) if available, else ``None``.
 * ``zoom``: Zoom.
 * ``row``: Row.
 * ``col``: Col.
 * ``x_size``: Horizontal size in SRID units.
 * ``y_size``: Vertical size in SRID units.
-* ``id``: Tuple of ``(zoom, col, row)``
+* ``index`` or ``id``: Tuple of ``(zoom, col, row)``
 * ``pixel_x_size``: Horizontal pixel size in SRID units.
 * ``pixel_y_size``: Vertical pixel size in SRID units.
 * ``left``: Left coordinate.
@@ -32,171 +126,26 @@ After initializing, the object has the following properties:
 ### Methods
 
 #### Get other Tiles
-```python
-get_parent(self)
-```
-Returns parent Tile.
-
-
-```python
-get_children(self)
-```
-
-Returns children Tiles.
-
-```python
-get_neighbors(connectedness=8)
-```
-* ``connectedness``: ``4`` or ``8``. Direct neighbors (up to 4) or corner neighbors (up to 8).
-
-Returns a maximum of 8 valid neighbor Tiles.
-
-```python
-intersecting(tilepyramid)
-```
-Return all tiles from tilepyramid intersecting with tile.
-
-This helps translating between TilePyramids with different metatiling
+* ``get_parent()``: Returns parent Tile.
+* ``get_children()``: Returns children Tiles.
+* ``get_neighbors(connectedness=8)``: Returns a maximum of 8 valid neighbor Tiles.
+    * ``connectedness``: ``4`` or ``8``. Direct neighbors (up to 4) or corner neighbors (up to 8).
+* ``intersecting(TilePyramid)``: Return all tiles from other TilePyramid intersecting with tile. This helps translating between TilePyramids with different metatiling
 settings.
-* ``tilepyramid``: ``TilePyramid`` object.
+    * ``tilepyramid``: ``TilePyramid`` object.
 
 
 #### Geometry
-```python
-bounds(pixelbuffer=0)
-```
-* ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+* ``bounds(pixelbuffer=0)``: Returns a tuple of ``(left, bottom, right, top)`` coordinates.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+* ``bbox(pixelbuffer=0)``: Returns a ``Polygon`` geometry.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+* ``affine(pixelbuffer=0)``: Returns an [``Affine``](https://github.com/sgillies/affine) object.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
 
-Returns a tuple of ``(left, bottom, right, top)`` coordinates.
-
-
-```python
-bbox(pixelbuffer=0)
-```
-* ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
-
-Returns a ``Polygon`` geometry.
-
-
-```python
-affine(pixelbuffer=0)
-```
-* ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
-
-Returns an [``Affine``](https://github.com/sgillies/affine) object.
 
 
 #### Other
-```python
-shape(pixelbuffer=0)
-```
-* ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
-
-Returns a tuple with ``(height, width)``.
-
-
-```python
-is_valid(self)
-```
-
-Returns ``True`` if tile ID is valid in this tile matrix and ``False`` if it isn't.
-
-
-## TilePyramid
-
-```python
-TilePyramid(projection, tile_size=256)
-```
-* ``type``: One out of ``geodetic`` or ``mercator``.
-* ``tile_size``: Optional, specifies the target resolution of each tile (i.e. each tile will have 256x256 px). Default is ``256``.
-
-### Variables
-* ``type``: The projection it was initialized with (either ``geodetic`` or ``mercator``).
-* ``tile_size``: The pixelsize per tile it was initialized with (default ``256``).
-* ``left``: Left boundary of tile matrix.
-* ``top``: Top boundary of tile matrix.
-* ``right ``: Right boundary of tile matrix.
-* ``bottom ``: Bottom boundary of tile matrix.
-* ``x_size``: Horizontal size of tile matrix in map coordinates.
-* ``y_size``: Vertical size of tile matrix in map coordinates.
-* ``crs``: CRS (e.g. ``{'init': u'EPSG:4326'}``)
-* ``srid``: Spatial reference ID (e.g. ``4326``)
-
-### Methods
-
-#### Matrix properties
-```python
-matrix_width(zoom)
-```
-* ``zoom``: Zoom level.
-Returns the number of columns in the current tile matrix.
-
-```python
-matrix_height(zoom)
-```
-Returns the number of rows in the current tile matrix.
-
-#### Geometry
-```python
-tile_x_size(zoom)
-```
-Returns a float, indicating the width of each tile at this zoom level in ``TilePyramid`` CRS units
-
-```python
-tile_y_size(zoom)
-```
-Returns a floats, indicating the height of each tile at this zoom level in ``TilePyramid`` CRS units.
-
-```python
-pixel_x_size(zoom)
-```
-Returns a float, indicating the vertical pixel size in ``TilePyramid`` CRS units.
-
-```python
-pixel_y_size(zoom)
-```
-Returns a float, indicating the horizontal pixel size in ``TilePyramid`` CRS units.
-
-```python
-top_left_tile_coords(zoom, row, col)
-```
-* ``row``: Row in ``TilePyramid``.
-* ``col``: Column in ``TilePyramid``.
-
-Returns a tuple of two floats, indicating the top left coordinates of the given tile.
-
-```python
-tile_bounds(zoom, row, col, pixelbuffer=None)
-```
-* ``pixelbuffer``: Optional, integer defining the width of the additional margin to take into account (e.g. ``pixelbuffer=1`` increases the tile size to 258x258px).
-
-Returns ``left``, ``bottom``, ``right``, ``top`` coordinates of given tile.
-
-```python
-tile_bbox(zoom, row, col, pixelbuffer=None)
-```
-Returns the bounding box for given tile as a ``Polygon``.
-
-#### Tiles
-```python
-intersecting(tile)
-```
-Return all tiles intersecting with tile.
-
-This helps translating between TilePyramids with different metatiling
-settings.
-* ``tile``: ``Tile`` object.
-
-```python
-tiles_from_bbox(geometry, zoom)
-```
-* ``geometry``: Must be a ``Polygon`` object.
-
-Returns tiles intersecting with the given bounding box at given zoom level.
-
-```python
-tiles_from_geom(geometry, zoom):
-```
-* ``geometry``: Must be one out of ``Polygon``, ``MultiPolygon``, ``LineString``, ``MultiLineString``, ``Point``, ``MultiPoint``.
-
-Returns tiles intersecting with the given geometry at given zoom level.
+* ``shape(pixelbuffer=0)``: Returns a tuple with ``(height, width)``.
+    * ``pixelbuffer``: Optional buffer around tile boundaries in pixels.
+* ``is_valid()``: Returns ``True`` if tile ID is valid in this tile matrix and ``False`` if it isn't.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,31 @@
+"""Fixtures for test suite."""
+
+import pytest
+
+
+@pytest.fixture
+def grid_definition_proj():
+    """Custom grid definition using a proj string."""
+    return {
+        "shape": (1, 1),
+        "bounds": (-4000000., -4000000., 4000000., 4000000.),
+        "is_global": False,
+        "proj": """
+            +proj=ortho
+            +lat_0=-90
+            +lon_0=0
+            +x_0=0
+            +y_0=0
+            +ellps=WGS84
+            +units=m +no_defs
+        """}
+
+
+@pytest.fixture
+def grid_definition_epsg():
+    """Custom grid definition using an EPSG code."""
+    return {
+        "shape": (1, 1),
+        "bounds": (2426378.0132, 1528101.2618, 6293974.6215, 5395697.8701),
+        "is_global": False,
+        "epsg": 3035}

--- a/test/test_custom_grids.py
+++ b/test/test_custom_grids.py
@@ -1,0 +1,32 @@
+"""TilePyramid creation."""
+
+import pytest
+from tilematrix import TilePyramid
+
+
+def test_proj_str(grid_definition_proj):
+    """Initialize with proj string."""
+    tp = TilePyramid(grid_definition_proj)
+    assert tp.tile(0, 0, 0).bounds() == grid_definition_proj["bounds"]
+
+
+def test_epsg_code(grid_definition_epsg):
+    """Initialize with EPSG code."""
+    tp = TilePyramid(grid_definition_epsg)
+    assert tp.tile(0, 0, 0).bounds() == grid_definition_epsg["bounds"]
+
+
+def test_shape_error(grid_definition_epsg):
+    """Raise error when shape aspect ratio is not bounds apsect ratio."""
+    grid_definition_epsg.update(
+        bounds=(2426378.0132, 1528101.2618, 6293974.6215, 5446513.5222))
+    with pytest.raises(ValueError):
+        TilePyramid(grid_definition_epsg)
+
+
+def test_neighbors(grid_definition_epsg):
+    """Initialize with EPSG code."""
+    tp = TilePyramid(grid_definition_epsg)
+    neighbor_ids = set([t.id for t in tp.tile(1, 0, 0).get_neighbors()])
+    control_ids = set([(1, 1, 0), (1, 0, 1), (1, 1, 1)])
+    assert len(neighbor_ids.symmetric_difference(control_ids)) == 0

--- a/tilematrix/_conf.py
+++ b/tilematrix/_conf.py
@@ -3,6 +3,9 @@
 # round coordinates
 ROUND = 20
 
+# bounds ratio vs shape ratio uncertainty
+DELTA = 1e-6
+
 # supported pyramid types
 PYRAMID_PARAMS = {
     "geodetic": {

--- a/tilematrix/_conf.py
+++ b/tilematrix/_conf.py
@@ -7,15 +7,15 @@ ROUND = 20
 PYRAMID_PARAMS = {
     "geodetic": {
         "shape": (2, 1),  # tile columns and rows at zoom level 0
-        "bounds": (-180., 90., 180., -90.),  # pyramid bounds in pyramid CRS
+        "bounds": (-180., -90., 180., 90.),  # pyramid bounds in pyramid CRS
         "is_global": True,  # if false, no antimeridian handling
         "epsg": 4326  # EPSG code for CRS
         },
     "mercator": {
         "shape": (1, 1),
         "bounds": (
-            -20037508.3427892, 20037508.3427892, 20037508.3427892,
-            -20037508.3427892),
+            -20037508.3427892, -20037508.3427892, 20037508.3427892,
+            20037508.3427892),
         "is_global": True,
         "epsg": 3857
         }

--- a/tilematrix/_tilepyramid.py
+++ b/tilematrix/_tilepyramid.py
@@ -40,7 +40,7 @@ class TilePyramid(object):
         self.type = projection
         self._shape = _funcs.Shape(*PYRAMID_PARAMS[projection]["shape"])
         self.bounds = _funcs.Bounds(*PYRAMID_PARAMS[projection]["bounds"])
-        self.left, self.top, self.right, self.bottom = self.bounds
+        self.left, self.bottom, self.right, self.top = self.bounds
         self.is_global = PYRAMID_PARAMS[projection]["is_global"]
         self.srid = PYRAMID_PARAMS[projection]["epsg"]
         self.crs = CRS().from_epsg(self.srid)


### PR DESCRIPTION
In addition to the two predifined grids ``mercator`` and ``geodetic``, custom grids using either EPSG codes or proj strings are now enabled.