### PR TITLE
Dump load dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 sudo: required
 language: python
 python:
-- '2.7'
 - '3.6'
 before_install:
 - sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 - sudo apt-add-repository -y ppa:ubuntugis/ubuntugis-unstable
 - sudo apt-get -y update
 - sudo apt-get install -y libgdal-dev build-essential libproj-dev
-- "pip install --no-binary :all: rasterio==1.0a12"
+- "pip install --no-binary :all: rasterio==1.0.21"
 install:
 - pip install -r requirements.txt
 - pip install pytest coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@ Changelog
 ----
 * ``TilePyramid.srid`` and ``TilePyramid.type``  are deprecated
 * ``GridDefinition`` can now be loaded from package root
-* ``GridDefinition`` got ``to_dict()`` and ``from_dict()``
+* ``GridDefinition`` got ``to_dict()`` and ``from_dict()`` methods
+
 
 0.18
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 0.19
 ----
+* Python 2 not supported anymore
 * ``TilePyramid.srid`` and ``TilePyramid.type``  are deprecated
 * ``GridDefinition`` can now be loaded from package root
 * ``GridDefinition`` got ``to_dict()`` and ``from_dict()`` methods

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 #########
 
+0.19
+----
+* ``TilePyramid.srid`` and ``TilePyramid.type``  are deprecated
+* ``GridDefinition`` can now be loaded from package root
+* ``GridDefinition`` got ``to_dict()`` and ``from_dict()``
+
 0.18
 ----
 * order of ``Tile.shape`` swapped to ``(height, width)`` in order to match rasterio array interpretation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 affine
 click
 geojson
-rasterio>=1.0a3
+rasterio>=1.0.21
 shapely
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ click
 geojson
 rasterio>=1.0.21
 shapely
-six

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Scientific/Engineering :: GIS',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6'
     ],
     setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'affine',
         'click',
         'geojson',
-        'rasterio>=1.0a3',
+        'rasterio>=1.0.21',
         'shapely',
         'six'
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(
         'click',
         'geojson',
         'rasterio>=1.0.21',
-        'shapely',
-        'six'
+        'shapely'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,17 @@
 """Fixtures for test suite."""
 
 import pytest
+from shapely.geometry import Polygon
+
+example_proj = """
+        +proj=ortho
+        +lat_0=-90
+        +lon_0=0
+        +x_0=0
+        +y_0=0
+        +ellps=WGS84
+        +units=m +no_defs
+    """
 
 
 @pytest.fixture
@@ -10,15 +21,8 @@ def grid_definition_proj():
         "shape": (1, 1),
         "bounds": (-4000000., -4000000., 4000000., 4000000.),
         "is_global": False,
-        "proj": """
-            +proj=ortho
-            +lat_0=-90
-            +lon_0=0
-            +x_0=0
-            +y_0=0
-            +ellps=WGS84
-            +units=m +no_defs
-        """}
+        "proj": example_proj
+    }
 
 
 @pytest.fixture
@@ -30,3 +34,40 @@ def grid_definition_epsg():
         "is_global": False,
         "epsg": 3035
     }
+
+
+@pytest.fixture
+def proj():
+    return example_proj
+
+
+@pytest.fixture
+def wkt():
+    return '''
+        PROJCS["ETRS89 / LAEA Europe",
+        GEOGCS["ETRS89",DATUM["European_Terrestrial_Reference_System_1989",
+        SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],
+        TOWGS84[0,0,0,0,0,0,0],
+        AUTHORITY["EPSG","6258"]],
+        PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4258"]],
+        PROJECTION["Lambert_Azimuthal_Equal_Area"],
+        PARAMETER["latitude_of_center",52],
+        PARAMETER["longitude_of_center",10],
+        PARAMETER["false_easting",4321000],
+        PARAMETER["false_northing",3210000],
+        UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+        AUTHORITY["EPSG","3035"]]
+    '''
+
+
+@pytest.fixture
+def invalid_geom():
+    return Polygon(
+        [
+            (0, 0), (0, 3), (3, 3), (3, 0), (2, 0), (2, 2),
+            (1, 2), (1, 1), (2, 1), (2, 0), (0, 0)
+        ]
+    )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,4 +28,5 @@ def grid_definition_epsg():
         "shape": (1, 1),
         "bounds": (2426378.0132, 1528101.2618, 6293974.6215, 5395697.8701),
         "is_global": False,
-        "epsg": 3035}
+        "epsg": 3035
+    }

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -69,6 +69,32 @@ def test_tiles():
         _run_tiles(zoom, bounds, output_format=output_format)
 
 
+def test_snap_bounds():
+    zoom = 6
+    bounds = (10, 20, 30, 40)
+    for grid in ["geodetic", "mercator"]:
+        _run_snap_bounds(zoom, bounds, "snap-bounds", grid=grid)
+    for metatiling in [1, 2, 4, 8, 16]:
+        _run_snap_bounds(zoom, bounds, "snap-bounds", metatiling=metatiling)
+    for pixelbuffer in [0, 1, 10]:
+        _run_snap_bounds(zoom, bounds, "snap-bounds", pixelbuffer=pixelbuffer)
+    for tile_size in [256, 512, 1024]:
+        _run_snap_bounds(zoom, bounds, "snap-bounds", tile_size=tile_size)
+
+
+def test_snap_bbox():
+    zoom = 6
+    bounds = (10, 20, 30, 40)
+    for grid in ["geodetic", "mercator"]:
+        _run_snap_bounds(zoom, bounds, "snap-bbox", grid=grid)
+    for metatiling in [1, 2, 4, 8, 16]:
+        _run_snap_bounds(zoom, bounds, "snap-bbox", metatiling=metatiling)
+    for pixelbuffer in [0, 1, 10]:
+        _run_snap_bounds(zoom, bounds, "snap-bbox", pixelbuffer=pixelbuffer)
+    for tile_size in [256, 512, 1024]:
+        _run_snap_bounds(zoom, bounds, "snap-bbox", tile_size=tile_size)
+
+
 def _run_bbox_bounds(
     zoom, row, col, command=None, grid="geodetic", metatiling=1, pixelbuffer=0,
     tile_size=256, output_format="WKT"
@@ -90,7 +116,6 @@ def _run_bbox_bounds(
     if command == "bounds":
         assert result.output.strip() == " ".join(map(str, tile.bounds(pixelbuffer)))
     elif output_format == "WKT":
-        print(result.output.strip())
         assert wkt.loads(result.output.strip()).almost_equals(tile.bbox(pixelbuffer))
     elif output_format == "GeoJSON":
         assert shape(
@@ -154,3 +179,18 @@ def _run_tiles(
     elif output_format == "GeoJSON":
         features = geojson.loads(result.output.strip())["features"]
         assert len(features) == len(tiles)
+
+
+def _run_snap_bounds(
+    zoom, bounds, command=None, grid="geodetic", metatiling=1, pixelbuffer=0,
+    tile_size=256
+):
+    left, bottom, right, top = bounds
+    result = CliRunner().invoke(tmx, [
+        "--pixelbuffer", str(pixelbuffer),
+        "--metatiling", str(metatiling),
+        "--grid", grid,
+        "--tile_size", str(tile_size),
+        command, str(zoom), str(left), str(bottom), str(right), str(top)
+    ])
+    assert result.exit_code == 0

--- a/test/test_dump_load.py
+++ b/test/test_dump_load.py
@@ -1,0 +1,26 @@
+from tilematrix import TilePyramid
+
+
+def test_geodetic():
+    tp = TilePyramid("geodetic", metatiling=2)
+    tp_dict = tp.to_dict()
+    assert isinstance(tp_dict, dict)
+    tp2 = TilePyramid.from_dict(tp_dict)
+    assert tp == tp2
+
+
+def test_mercator():
+    tp = TilePyramid("mercator", metatiling=4)
+    tp_dict = tp.to_dict()
+    assert isinstance(tp_dict, dict)
+    tp2 = TilePyramid.from_dict(tp_dict)
+    assert tp == tp2
+
+
+def test_custom(grid_definition_proj, grid_definition_epsg):
+    for grid_def in [grid_definition_proj, grid_definition_epsg]:
+        tp = TilePyramid(grid_def, metatiling=8)
+        tp_dict = tp.to_dict()
+        assert isinstance(tp_dict, dict)
+        tp2 = TilePyramid.from_dict(tp_dict)
+        assert tp == tp2

--- a/test/test_geometries.py
+++ b/test/test_geometries.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Tile geometries and tiles from geometries."""
 
 import pytest
@@ -181,6 +180,13 @@ def test_tiles_from_empty_geom():
     tp = TilePyramid("geodetic")
     empty_tiles = {tile.id for tile in tp.tiles_from_geom(test_geom, 6)}
     assert empty_tiles == set([])
+
+
+def test_tiles_from_invalid_geom(invalid_geom):
+    """Get tiles from empty geometry."""
+    tp = TilePyramid("geodetic")
+    with pytest.raises(ValueError):
+        list(tp.tiles_from_geom(invalid_geom, 6))
 
 
 def test_tiles_from_point():

--- a/test/test_grids.py
+++ b/test/test_grids.py
@@ -1,7 +1,29 @@
 """TilePyramid creation."""
 
 import pytest
-from tilematrix import TilePyramid
+from tilematrix import TilePyramid, GridDefinition, PYRAMID_PARAMS
+
+
+def test_grid_init(grid_definition_proj):
+    grid = GridDefinition(**dict(PYRAMID_PARAMS["geodetic"], grid="custom"))
+    custom_grid = TilePyramid(grid_definition_proj).grid
+    # make sure standard grid gets detected
+    assert grid.type == "geodetic"
+    # create grid from grid
+    assert GridDefinition(grid)
+    # create grid from dict
+    assert GridDefinition.from_dict(grid.to_dict())
+    # __repr__
+    assert str(grid)
+    assert str(custom_grid)
+    # __hash__
+    assert hash(grid)
+    assert hash(custom_grid)
+
+
+def test_deprecated():
+    grid = TilePyramid("geodetic").grid
+    assert grid.srid
 
 
 def test_proj_str(grid_definition_proj):
@@ -19,7 +41,8 @@ def test_epsg_code(grid_definition_epsg):
 def test_shape_error(grid_definition_epsg):
     """Raise error when shape aspect ratio is not bounds apsect ratio."""
     grid_definition_epsg.update(
-        bounds=(2426378.0132, 1528101.2618, 6293974.6215, 5446513.5222))
+        bounds=(2426378.0132, 1528101.2618, 6293974.6215, 5446513.5222)
+    )
     with pytest.raises(ValueError):
         TilePyramid(grid_definition_epsg)
 
@@ -30,3 +53,4 @@ def test_neighbors(grid_definition_epsg):
     neighbor_ids = set([t.id for t in tp.tile(1, 0, 0).get_neighbors()])
     control_ids = set([(1, 1, 0), (1, 0, 1), (1, 1, 1)])
     assert len(neighbor_ids.symmetric_difference(control_ids)) == 0
+

--- a/test/test_helper_funcs.py
+++ b/test/test_helper_funcs.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
-"""TilePyramid creation."""
-
+import pytest
+from rasterio.crs import CRS
 from shapely.geometry import box
 
-from tilematrix import clip_geometry_to_srs_bounds, TilePyramid
+from tilematrix import clip_geometry_to_srs_bounds, TilePyramid, validate_zoom
+from tilematrix._funcs import _verify_shape_bounds, _get_crs
 
 
-def test_antimeridian_clip():
+def test_antimeridian_clip(invalid_geom):
     """Clip on antimeridian."""
     tp = TilePyramid("geodetic")
     tp_bounds = box(tp.left, tp.bottom, tp.right, tp.top)
@@ -45,11 +45,14 @@ def test_antimeridian_clip():
         assert sub_geom.within(tp_bounds)
     assert len(out_geom) == 3
 
+    # fail on invalid geometry
+    with pytest.raises(ValueError):
+        clip_geometry_to_srs_bounds(invalid_geom, tp)
+
 
 def test_no_clip():
     """Geometry is within TilePyramid bounds."""
     tp = TilePyramid("geodetic")
-    tp_bounds = box(tp.left, tp.bottom, tp.right, tp.top)
     geometry = box(177.5, 67.5, -177.5, 73.125)
 
     # no multipart
@@ -61,3 +64,36 @@ def test_no_clip():
     assert isinstance(out_geom, list)
     assert len(out_geom) == 1
     assert geometry == out_geom[0]
+
+
+def test_validate_zoom():
+    with pytest.raises(TypeError):
+        validate_zoom(5.0)
+    with pytest.raises(ValueError):
+        validate_zoom(-1)
+
+
+def test_verify_shape_bounds():
+    # invalid shape
+    with pytest.raises(TypeError):
+        _verify_shape_bounds((1, 2, 3), (1, 2, 3, 4))
+    # invalid bounds
+    with pytest.raises(TypeError):
+        _verify_shape_bounds((1, 2), (1, 2, 3, 4, 5))
+
+    _verify_shape_bounds((2, 1), (1, 2, 3, 6))
+
+
+def test_get_crs(proj, wkt):
+    # no dictionary
+    with pytest.raises(TypeError):
+        _get_crs("no dict")
+    # valid WKT
+    assert isinstance(_get_crs(dict(wkt=wkt)), CRS)
+    # valid EPSG
+    assert isinstance(_get_crs(dict(epsg=3857)), CRS)
+    # valid PROJ
+    assert isinstance(_get_crs(dict(proj=proj)), CRS)
+    # none of above
+    with pytest.raises(TypeError):
+        _get_crs(dict(something_else=None))

--- a/test/test_tile.py
+++ b/test/test_tile.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Tile properties."""
 
 from affine import Affine
@@ -69,7 +68,7 @@ def test_get_children():
     assert test_children == children
 
 
-def test_get_neighbors():
+def test_get_neighbors(grid_definition_proj):
     """Get Tile neighbors."""
     tp = TilePyramid("geodetic")
 
@@ -124,6 +123,14 @@ def test_get_neighbors():
     except ValueError:
         pass
 
+    # neighbors on non-global tilepyramids
+    tp = TilePyramid(grid_definition_proj)
+    zoom = 5
+    max_col = tp.matrix_width(zoom) - 1
+    tile = tp.tile(zoom=zoom, row=3, col=max_col)
+    # don't wrap around antimeridian, i.e. there are no tile neighbors
+    assert len(tile.get_neighbors()) == 5
+
 
 def test_intersecting():
     """Get intersecting Tiles from other TilePyramid."""
@@ -151,3 +158,9 @@ def test_tile_tuple():
     tp = TilePyramid("geodetic")
     a = tp.tile(5, 5, 5)
     assert tuple(a) == (5, 5, 5, )
+
+
+def test_deprecated():
+    tp = TilePyramid("geodetic")
+    tile = tp.tile(5, 5, 5)
+    assert tile.srid

--- a/tilematrix/__init__.py
+++ b/tilematrix/__init__.py
@@ -1,7 +1,8 @@
 """Main package entry point."""
 
+from ._conf import PYRAMID_PARAMS
+from ._funcs import clip_geometry_to_srs_bounds, snap_bounds, validate_zoom
 from ._grid import GridDefinition
-from ._funcs import clip_geometry_to_srs_bounds, snap_bounds
 from ._tilepyramid import TilePyramid
 from ._tile import Tile
 from ._types import Bounds, Shape, TileIndex
@@ -10,11 +11,13 @@ __all__ = [
     'Bounds',
     'clip_geometry_to_srs_bounds',
     'GridDefinition',
+    'PYRAMID_PARAMS',
     'Shape',
     'snap_bounds',
     'TilePyramid',
     'Tile',
     'TileIndex',
+    'validate_zoom'
 ]
 
 

--- a/tilematrix/__init__.py
+++ b/tilematrix/__init__.py
@@ -1,19 +1,21 @@
 """Main package entry point."""
 
+from ._grid import GridDefinition
+from ._funcs import clip_geometry_to_srs_bounds, snap_bounds
 from ._tilepyramid import TilePyramid
 from ._tile import Tile
-from ._funcs import clip_geometry_to_srs_bounds, snap_bounds
 from ._types import Bounds, Shape, TileIndex
 
 __all__ = [
+    'Bounds',
+    'clip_geometry_to_srs_bounds',
+    'GridDefinition',
+    'Shape',
+    'snap_bounds',
     'TilePyramid',
     'Tile',
     'TileIndex',
-    'Shape',
-    'Bounds',
-    'clip_geometry_to_srs_bounds',
-    'snap_bounds'
 ]
 
 
-__version__ = "0.18"
+__version__ = "0.19"

--- a/tilematrix/_conf.py
+++ b/tilematrix/_conf.py
@@ -12,14 +12,18 @@ PYRAMID_PARAMS = {
         "shape": (1, 2),  # tile rows and columns at zoom level 0
         "bounds": (-180., -90., 180., 90.),  # pyramid bounds in pyramid CRS
         "is_global": True,  # if false, no antimeridian handling
-        "epsg": 4326  # EPSG code for CRS
-        },
+        "srs": {
+            "epsg": 4326  # EPSG code for CRS
+        }
+    },
     "mercator": {
         "shape": (1, 1),
         "bounds": (
             -20037508.3427892, -20037508.3427892, 20037508.3427892,
             20037508.3427892),
         "is_global": True,
-        "epsg": 3857
+        "srs": {
+            "epsg": 3857
         }
     }
+}

--- a/tilematrix/_funcs.py
+++ b/tilematrix/_funcs.py
@@ -101,10 +101,13 @@ def _verify_shape_bounds(shape, bounds):
             bounds.left,
             bounds.bottom,
             bounds.left + shape.width * min_length,
-            bounds.bottom + shape.height * min_length)
+            bounds.bottom + shape.height * min_length
+        )
         raise ValueError(
             "shape ratio (%s) must equal bounds ratio (%s); try %s" % (
-                shape_ratio, bounds_ratio, proposed_bounds))
+                shape_ratio, bounds_ratio, proposed_bounds
+            )
+        )
 
 
 def _get_crs(srs):
@@ -203,10 +206,7 @@ def _tiles_from_cleaned_bounds(tp, bounds, zoom):
     lb = _tile_from_xy(tp, bounds.left, bounds.bottom, zoom, on_edge_use="rt")
     rt = _tile_from_xy(tp, bounds.right, bounds.top, zoom, on_edge_use="lb")
     for tile_id in product([zoom], range(rt.row, lb.row + 1), range(lb.col, rt.col + 1)):
-        try:
-            yield tp.tile(*tile_id)
-        except ValueError:
-            pass
+        yield tp.tile(*tile_id)
 
 
 def _tile_from_xy(tp, x, y, zoom, on_edge_use="rb"):

--- a/tilematrix/_grid.py
+++ b/tilematrix/_grid.py
@@ -1,4 +1,3 @@
-import six
 import warnings
 
 from ._conf import PYRAMID_PARAMS
@@ -12,7 +11,7 @@ class GridDefinition(object):
     def __init__(
         self, grid=None, shape=None, bounds=None, srs=None, is_global=False, **kwargs
     ):
-        if isinstance(grid, six.string_types) and grid in PYRAMID_PARAMS:
+        if isinstance(grid, str) and grid in PYRAMID_PARAMS:
             self.type = grid
             self.shape = Shape(*PYRAMID_PARAMS[grid]["shape"])
             self.bounds = Bounds(*PYRAMID_PARAMS[grid]["bounds"])
@@ -22,20 +21,13 @@ class GridDefinition(object):
         elif grid is None or grid == "custom":
             for i in ["proj", "epsg"]:
                 if i in kwargs:
-                    if srs is None:
-                        srs = {i: kwargs[i]}
-                        warnings.warn(
-                            DeprecationWarning(
-                                "'%s' should be packed into a dictionary and passed to "
-                                "'srs'" % i
-                            )
+                    srs = {i: kwargs[i]} if srs is None else srs
+                    warnings.warn(
+                        DeprecationWarning(
+                            "'%s' should be packed into a dictionary and passed to "
+                            "'srs'" % i
                         )
-                    else:
-                        warnings.warn(
-                            DeprecationWarning(
-                                "srs parameter found, '%s' will be ignored" % i
-                            )
-                        )
+                    )
             self.type = "custom"
             _verify_shape_bounds(shape=shape, bounds=bounds)
             self.shape = Shape(*shape)
@@ -75,7 +67,7 @@ class GridDefinition(object):
             type=self.type,
         )
 
-    def from_dict(self, config_dict):
+    def from_dict(config_dict):
         return GridDefinition(**config_dict)
 
     def __eq__(self, other):

--- a/tilematrix/_tile.py
+++ b/tilematrix/_tile.py
@@ -1,7 +1,8 @@
 """Tile class."""
 
-from shapely.geometry import box
 from affine import Affine
+from shapely.geometry import box
+import warnings
 
 from ._conf import ROUND
 from ._funcs import _tile_intersecting_tilepyramid
@@ -40,7 +41,11 @@ class Tile(object):
             self.tile_pyramid.top-((self.row)*self.y_size), ROUND))
         self.right = self.left + self.x_size
         self.bottom = self.top - self.y_size
-        self.srid = tile_pyramid.srid
+
+    @property
+    def srid(self):
+        warnings.warn(DeprecationWarning("'srid' attribute is deprecated"))
+        return self.grid.srid
 
     @property
     def width(self):

--- a/tilematrix/_tile.py
+++ b/tilematrix/_tile.py
@@ -45,7 +45,7 @@ class Tile(object):
     @property
     def srid(self):
         warnings.warn(DeprecationWarning("'srid' attribute is deprecated"))
-        return self.grid.srid
+        return self.tp.grid.srid
 
     @property
     def width(self):

--- a/tilematrix/_tilepyramid.py
+++ b/tilematrix/_tilepyramid.py
@@ -205,6 +205,8 @@ class TilePyramid(object):
         validate_zoom(zoom)
         if geometry.is_empty:
             return
+        if not geometry.is_valid:
+            raise ValueError("no valid geometry: %s" % geometry.type)
         if geometry.geom_type == "Point":
             yield self.tile_from_xy(geometry.x, geometry.y, zoom)
         elif geometry.geom_type == "MultiPoint":
@@ -219,8 +221,6 @@ class TilePyramid(object):
             for tile in self.tiles_from_bbox(geometry, zoom):
                 if prepared_geometry.intersects(tile.bbox()):
                     yield tile
-        else:
-            raise ValueError("no valid geometry: %s" % geometry.type)
 
     def tile_from_xy(self, x, y, zoom, on_edge_use="rb"):
         """

--- a/tilematrix/tmx/main.py
+++ b/tilematrix/tmx/main.py
@@ -150,7 +150,7 @@ def tiles(ctx, bounds, zoom):
 @click.argument('BOUNDS', nargs=4, type=click.FLOAT, required=True)
 @click.pass_context
 def snap_bounds(ctx, bounds, zoom):
-    """Print Tiles from bounds."""
+    """nap bounds to tile grid."""
     click.echo('%s %s %s %s' % tilematrix.snap_bounds(
         bounds=bounds,
         tile_pyramid=TilePyramid(
@@ -168,7 +168,7 @@ def snap_bounds(ctx, bounds, zoom):
 @click.argument('BOUNDS', nargs=4, type=click.FLOAT, required=True)
 @click.pass_context
 def snap_bbox(ctx, bounds, zoom):
-    """Print Tiles from bounds."""
+    """Snap bbox to tile grid."""
     click.echo(box(*tilematrix.snap_bounds(
         bounds=bounds,
         tile_pyramid=TilePyramid(


### PR DESCRIPTION
* Python 2 not supported anymore
* ``TilePyramid.srid`` and ``TilePyramid.type``  are deprecated
* ``GridDefinition`` can now be loaded from package root
* ``GridDefinition`` got ``to_dict()`` and ``from_dict()`` methods
