### PR TITLE
metatile clipping but enabling pixelbuffers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 ----
 * fixed pixel size calculation on irregular grids with metatiling (closing #33)
 * ``TilePyramid.tile_x_size()``, ``TilePyramid.tile_y_size()``, ``TilePyramid.tile_height()``, ``TilePyramid.tile_width()`` are deprecated
+* metatiles are clipped to ``TilePyramid.bounds`` but ``pixelbuffer`` of edge tiles can exceed them unless it is a global grid
 
 0.19
 ----

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015, 2016, 2017, 2018 EOX IT Services GmbH
+Copyright (c) 2015 - 2019 EOX IT Services GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/test_tile.py
+++ b/test/test_tile.py
@@ -182,3 +182,9 @@ def test_invalid_id():
     # row exceeds
     with pytest.raises(ValueError):
         tp.tile(5, 0, 500)
+
+
+def test_tile_sizes():
+    tp = TilePyramid("geodetic")
+    tile = tp.tile(5, 5, 5)
+    assert tile.x_size == tile.y_size


### PR DESCRIPTION
metatiles are clipped to TilePyramid.bounds but pixelbuffer of edge tiles can exceed them unless it is a global grid